### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
                 <configuration>
                     <!-- value of flags will be interpolated into the java invocation -->
                     <!-- as "java $flags -jar ..." -->
-                    <flags>-Xmx2G</flags>
+                    <flags>-Xmx4G</flags>
 
                     <!-- (optional) name for binary executable, if not set will just -->
                     <!-- make the regular jar artifact executable -->


### PR DESCRIPTION
Max heap size of 2G sometimes causes wftop to crash due to memory running out. Increase default size to 4G.