### PR TITLE
MONIT-16812 Fixed export path issue

### DIFF
--- a/src/main/java/com/wavefront/tools/wftop/panels/NamespacePanel.java
+++ b/src/main/java/com/wavefront/tools/wftop/panels/NamespacePanel.java
@@ -223,7 +223,7 @@ public abstract class NamespacePanel extends Panel {
       footer.removeComponent(stopStartBtn);
       header.addComponent(stopwatchTime.withBorder(Borders.singleLine()).
           setLayoutData(BorderLayout.Location.TOP));
-      this.exportFile = "./" + exportFile;
+      this.exportFile = exportFile;
       setUpCSVWriter();
     }
   }


### PR DESCRIPTION
Changed export logic to accept file path. Existing logic prefixes '.' before file path. This is preventing to give path.