### PR TITLE
MONIT-31879 : CVE-2021-20293 (6.1) - wavefrontHQ/wftop (java-lib)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>java-lib</artifactId>
-            <version>2022-08.2</version>
+            <version>2022-10.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Upgraded java-lib from 2022-08.2 to 2022-10.1
<img width="916" alt="image" src="https://user-images.githubusercontent.com/105360657/204712081-5fc61266-8768-4184-bacc-86abd9cc1be6.png">
