### PR TITLE
MONIT-32185: CVE-2022-42003 (7.5) - wavefrontHQ/wftop (jackson-databind via java-lib)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.wavefront</groupId>
             <artifactId>java-lib</artifactId>
-            <version>2022-10.1</version>
+            <version>2023-02.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -60,6 +60,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
             <version>4.13.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.14.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Updated java-lib to 2023-02.1. The latest version of java-lib does not have jackson-databind which is now getting imported from avro. Added jackson-databind explicitly.
![image](https://user-images.githubusercontent.com/105360657/220535056-a771133e-9cc7-4658-b9fa-24805e7b79be.png)
<img width="1684" alt="image" src="https://user-images.githubusercontent.com/105360657/221543843-750bde0b-8a53-48ef-ab80-568f53f5848b.png">
